### PR TITLE
Add receipt handling functions #3

### DIFF
--- a/src/Classes/PoshoverNotificationStatus.ps1
+++ b/src/Classes/PoshoverNotificationStatus.ps1
@@ -1,0 +1,12 @@
+class PoshoverNotificationStatus {
+    [string]$Receipt
+    [bool]$Acknowledged
+    [datetime]$AcknowledgedAt
+    [string]$AcknowledgedBy
+    [string]$AcknowledgedByDevice
+    [datetime]$LastDeliveredAt
+    [bool]$Expired
+    [datetime]$ExpiresAt
+    [bool]$CalledBack
+    [datetime]$CalledBackAt
+}

--- a/src/Poshover.Format.ps1xml
+++ b/src/Poshover.Format.ps1xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+    <ViewDefinitions>
+        <View>
+            <Name>Pushover Notification Status</Name>
+            <ViewSelectedBy>
+                <TypeName>PoshoverNotificationStatus</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Width>30</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>30</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>12</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>30</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>20</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>7</Width>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Receipt</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>LastDeliveredAt</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Acknowledged</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>AcknowledgedAt</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>AcknowledgedByDevice</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Expired</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+    </ViewDefinitions>
+</Configuration>

--- a/src/Poshover.psd1
+++ b/src/Poshover.psd1
@@ -63,7 +63,7 @@ PowerShellVersion = '5.1'
 # TypesToProcess = @()
 
 # Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+FormatsToProcess = @('.\Poshover.Format.ps1xml')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()

--- a/src/Public/Get-PushoverStatus.ps1
+++ b/src/Public/Get-PushoverStatus.ps1
@@ -1,0 +1,87 @@
+function Get-PushoverStatus {
+    [CmdletBinding()]
+    [OutputType([PoshoverNotificationStatus])]
+    param (
+        # Specifies the Pushover application API token/key.
+        # Note: The default value will be used if it has been previously set with Set-PushoverConfig
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        $Token,
+
+        # Specifies the receipt received from emergency notifications sent using Send-Pushover
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string]
+        $Receipt
+    )
+
+    begin {
+        $config = Get-PushoverConfig
+        $uriBuilder = [uribuilder]($config.ApiUri + '/receipts')
+    }
+
+    process {
+        if ($null -eq $Token) {
+            $Token = $config.Token
+            if ($null -eq $Token) {
+                throw "Token not provided and no default application token has been set using Set-PushoverConfig."
+            }
+        }
+        $uriBuilder.Path += "/$Receipt.json"
+        $uriBuilder.Query = "token=" + ($Token | ConvertTo-PlainText)
+        try {
+            $uriBuilder.Query = "token=" + ($Token | ConvertTo-PlainText)
+            $response = Invoke-RestMethod -Method Get -Uri $uriBuilder.Uri
+        }
+        catch {
+            Write-Verbose 'Handling HTTP error in Invoke-RestMethod response'
+            $statusCode = $_.Exception.Response.StatusCode.value__
+            Write-Verbose "HTTP status code $statusCode"
+            if ($statusCode -lt 400 -or $statusCode -gt 499) {
+                throw
+            }
+
+            try {
+                Write-Verbose 'Parsing HTTP request error response'
+                $stream = $_.Exception.Response.GetResponseStream()
+                $reader = [io.streamreader]::new($stream)
+                $response = $reader.ReadToEnd() | ConvertFrom-Json
+                if ([string]::IsNullOrWhiteSpace($response)) {
+                    throw $_
+                }
+                Write-Verbose "Response body:`r`n$response"
+            }
+            finally {
+                $reader.Dispose()
+            }
+        }
+
+        if ($response.status -eq 1) {
+            [PoshoverNotificationStatus]@{
+                Receipt = $Receipt
+                Acknowledged = [bool]$response.acknowledged
+                AcknowledgedAt = [datetimeoffset]::FromUnixTimeSeconds($response.acknowledged_at).DateTime.ToLocalTime()
+                AcknowledgedBy = $response.acknowledged_by
+                AcknowledgedByDevice = $response.acknowledged_by_device
+                LastDeliveredAt = [datetimeoffset]::FromUnixTimeSeconds($response.last_delivered_at).DateTime.ToLocalTime()
+                Expired = [bool]$response.expired
+                ExpiresAt = [datetimeoffset]::FromUnixTimeSeconds($response.expires_at).DateTime.ToLocalTime()
+                CalledBack = [bool]$response.called_back
+                CalledBackAt = [datetimeoffset]::FromUnixTimeSeconds($response.called_back_at).DateTime.ToLocalTime()
+            }
+        }
+        else {
+            if ($null -ne $response.error) {
+                Write-Error $response.error
+            }
+            elseif ($null -ne $response.errors) {
+                foreach ($problem in $response.errors) {
+                    Write-Error $problem
+                }
+            }
+            else {
+                $response
+            }
+        }
+    }
+}

--- a/src/Public/Wait-Pushover.ps1
+++ b/src/Public/Wait-Pushover.ps1
@@ -1,0 +1,46 @@
+function Wait-Pushover {
+    [CmdletBinding()]
+    param (
+        # Specifies the Pushover application API token/key.
+        # Note: The default value will be used if it has been previously set with Set-PushoverConfig
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [securestring]
+        $Token,
+
+        # Specifies the receipt received from emergency notifications sent using Send-Pushover
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string]
+        $Receipt,
+
+        # Specifies the interval between each Pushover API request for receipt status
+        [Parameter()]
+        [ValidateRange(5, 10800)]
+        [int]
+        $Interval = 10
+    )
+
+    begin {
+        $config = Get-PushoverConfig
+    }
+
+    process {
+        if ($null -eq $Token) {
+            $Token = $config.Token
+            if ($null -eq $Token) {
+                throw "Token not provided and no default application token has been set using Set-PushoverConfig."
+            }
+        }
+
+        $timeoutAt = (Get-Date).AddHours(3)
+        while ((Get-Date) -lt $timeoutAt.AddSeconds($Interval)) {
+            $status = Get-PushoverStatus -Token $Token -Receipt $Receipt -ErrorAction Stop
+            $timeoutAt = $status.ExpiresAt
+            if ($status.Acknowledged -or $status.Expired) {
+                break
+            }
+            Start-Sleep -Seconds $Interval
+        }
+        Write-Output $status
+    }
+}


### PR DESCRIPTION
Added `Get-PushoverStatus` and Wait-Pushover. The `Get-PushoverStatus` function will take the receipt from Send-Pushover and return a `[PoshoverNotificationStatus]` object with all the relevant properties made "PowerShell-friendly" like converting the 0/1 to $false/$true, and converting the unix UTC timestamps to local datetime's. I also added a format file to present the status object in a more friendly way, omitting a few of the extraneous properties (extraneous in my opinion, for most cases where you're looking at it in the terminal).

The `Wait-Pushover` will take a receipt just like `Get-PushoverStatus`, but it will continue polling for you every 10 seconds by default (minimum 10 seconds, maximum 3 hours), and it will only return once the notification has expired or been acknowledged. At the end, the last status is returned to the pipeline so you can check it to see if it was ack'd or expired and who ack'd it.