### PR TITLE
Resolve some PSScriptAnalyzer warnings

### DIFF
--- a/src/Poshover.psd1
+++ b/src/Poshover.psd1
@@ -72,13 +72,13 @@ FormatsToProcess = @('.\Poshover.Format.ps1xml')
 FunctionsToExport = '*'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = '*'
+CmdletsToExport = @()
 
 # Variables to export from this module
-VariablesToExport = '*'
+VariablesToExport = @()
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = '*'
+AliasesToExport = @()
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()

--- a/src/Private/Import-PushoverConfig.ps1
+++ b/src/Private/Import-PushoverConfig.ps1
@@ -7,6 +7,7 @@ function Import-PushoverConfig {
         can be imported, the function returns true. Otherwise it returns false.
     #>
     [CmdletBinding()]
+    [OutputType([bool])]
     param ()
 
     process {

--- a/src/Public/Reset-PushoverConfig.ps1
+++ b/src/Public/Reset-PushoverConfig.ps1
@@ -3,17 +3,19 @@ function Reset-PushoverConfig {
     .SYNOPSIS
         Reset Poshover module's configuration to default values
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param ()
 
     process {
-        Write-Verbose "Using the default module configuration"
-        $script:config = @{
-            PushoverApiDefaultUri = 'https://api.pushover.net/1'
-            PushoverApiUri = 'https://api.pushover.net/1'
-            DefaultApplicationToken = $null
-            DefaultUserToken = $null
+        if ($PSCmdlet.ShouldProcess("Poshover Module Configuration", "Reset to default")) {
+            Write-Verbose "Using the default module configuration"
+            $script:config = @{
+                PushoverApiDefaultUri = 'https://api.pushover.net/1'
+                PushoverApiUri = 'https://api.pushover.net/1'
+                DefaultApplicationToken = $null
+                DefaultUserToken = $null
+            }
+            Save-PushoverConfig
         }
-        Save-PushoverConfig
     }
 }

--- a/src/Public/Set-PushoverConfig.ps1
+++ b/src/Public/Set-PushoverConfig.ps1
@@ -16,7 +16,7 @@ function Set-PushoverConfig {
         Sets the Pushover API URI to http://localhost:8888 for the duration of the PowerShell session
         or until the Poshover module is forcefully imported again.
     #>
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         # Species the base URI to which all HTTP requests should be sent. Recommended to change this only for the purposes of test automation.
         [Parameter()]
@@ -41,13 +41,19 @@ function Set-PushoverConfig {
 
     process {
         if ($PSBoundParameters.ContainsKey('ApiUri')) {
-            $script:config.PushoverAPiUri = $ApiUri.ToString()
+            if ($PSCmdlet.ShouldProcess("Pushover ApiUri", "Set value to '$ApiUri'")) {
+                $script:config.PushoverAPiUri = $ApiUri.ToString()
+            }
         }
         if ($PSBoundParameters.ContainsKey('Token')) {
-            $script:config.DefaultAppToken = $Token
+            if ($PSCmdlet.ShouldProcess("Pushover Default Application Token", "Set value")) {
+                $script:config.DefaultAppToken = $Token
+            }
         }
         if ($PSBoundParameters.ContainsKey('User')) {
-            $script:config.DefaultUserToken = $User
+            if ($PSCmdlet.ShouldProcess("Pushover Default User Key", "Set value")) {
+                $script:config.DefaultUserToken = $User
+            }
         }
 
         if (-not $Temporary) {


### PR DESCRIPTION
There are some "unavoidable" warnings like...

- Lines ending in whitespace in the psd1 file. This happens because of the way Microsoft generate the file. I don't want to bother with finding a way to find/remove whitespace after automatically regenerating that file every build.
- Unused variables in the argument completer registered in the psm1 file. Those parameters aren't needed and if I remove them, it probably breaks the delegate when using it with the Register-ArgumentCompleter function. It doesn't bother me so I'm not going to experiment with it for now.